### PR TITLE
methodRef is accepted only if the scope is a name or field

### DIFF
--- a/java/src/main/java/eu/solven/cleanthat/engine/java/refactorer/mutators/LambdaIsMethodReference.java
+++ b/java/src/main/java/eu/solven/cleanthat/engine/java/refactorer/mutators/LambdaIsMethodReference.java
@@ -223,6 +223,13 @@ public class LambdaIsMethodReference extends AJavaparserNodeMutator {
 		}
 		var scope = optScope.get();
 
+		if (!scope.isNameExpr() && !scope.isFieldAccessExpr()) {
+			// https://github.com/solven-eu/cleanthat/issues/847
+			// There is a risk of side-effect if the scope is not the lambda parameter (e.g. if the lambda chains
+			// multiple calls)
+			return false;
+		}
+
 		if (methodCallExpr.getArguments().size() == 1 && methodCallExpr.getArguments().get(0).isNameExpr()
 				&& methodCallExpr.getArguments().get(0).asNameExpr().getName().equals(singleParameter.getName())) {
 

--- a/java/src/main/java/eu/solven/cleanthat/engine/java/refactorer/mutators/LambdaIsMethodReference.java
+++ b/java/src/main/java/eu/solven/cleanthat/engine/java/refactorer/mutators/LambdaIsMethodReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Benoit Lacelle - SOLVEN
+ * Copyright 2023-2024 Benoit Lacelle - SOLVEN
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java/src/test/java/eu/solven/cleanthat/engine/java/refactorer/cases/do_not_format_me/TestLambdaIsMethodReferenceCases.java
+++ b/java/src/test/java/eu/solven/cleanthat/engine/java/refactorer/cases/do_not_format_me/TestLambdaIsMethodReferenceCases.java
@@ -7,6 +7,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -246,6 +247,16 @@ public class TestLambdaIsMethodReferenceCases extends AJavaparserRefactorerCases
 	public static class CaseCastToGeneric {
 		public List<?> pre(Stream<? extends Class<?>> s) {
 			return s.map(m -> (Class<? extends CharSequence>) m).collect(Collectors.toList());
+		}
+	}
+
+	// https://github.com/solven-eu/cleanthat/issues/847
+	@UnmodifiedMethod
+	public static class CaseRootIsNotLambdaVariable {
+		// Must not be turned into
+		// `o.ifPresent(sb.append("/")::append);`
+		public void pre(Optional<?> o, StringBuilder sb) {
+			o.ifPresent(s -> sb.append("/").append(s));
 		}
 	}
 


### PR DESCRIPTION
Handles https://github.com/solven-eu/cleanthat/issues/847

---

I'm pretty sure the fix is partial: I feel there is more legit cases than `NameExpr` or `FieldRefExpr`.