### PR TITLE
Remove redundant final modifier from private methods

### DIFF
--- a/java/src/main/java/eu/solven/cleanthat/engine/java/refactorer/mutators/UnnecessaryModifier.java
+++ b/java/src/main/java/eu/solven/cleanthat/engine/java/refactorer/mutators/UnnecessaryModifier.java
@@ -141,6 +141,9 @@ public class UnnecessaryModifier extends AJavaparserNodeMutator {
 				if (isStatic) {
 					return false;
 				}
+				if (isFinal && ((MethodDeclaration) parentNode).isPrivate()) {
+					return removeModifier(modifier);
+				}
 			} else if (isInterfaceLike(parentNode)) {
 				// interfaceLike are implicitly static and abstract
 				if (isStatic || isAbstract) {

--- a/java/src/test/java/eu/solven/cleanthat/engine/java/refactorer/cases/do_not_format_me/TestUnnecessaryModifierCases.java
+++ b/java/src/test/java/eu/solven/cleanthat/engine/java/refactorer/cases/do_not_format_me/TestUnnecessaryModifierCases.java
@@ -224,6 +224,19 @@ public class TestUnnecessaryModifierCases extends AJavaparserRefactorerCases {
 			// public and static are redundant
 			public static enum MyEnum {
 			}
+
+			// final is redundant
+			private static final void privateStaticFinalMethod() {
+			}
+
+			// final is not redundant
+			// https://stackoverflow.com/questions/1743715/behaviour-of-final-static-method/1743748#1743748
+			static final void staticFinalMethod() {
+			}
+
+			// final is redundant
+			private final void privateFinalMethod() {
+			}
 		}
 
 		public static class Post {
@@ -268,6 +281,19 @@ public class TestUnnecessaryModifierCases extends AJavaparserRefactorerCases {
 
 			// public and static are redundant
 			public enum MyEnum {
+			}
+
+			// final is redundant
+			private static void privateStaticFinalMethod() {
+			}
+
+			// final is not redundant
+			// https://stackoverflow.com/questions/1743715/behaviour-of-final-static-method/1743748#1743748
+			static final void staticFinalMethod() {
+			}
+
+			// final is redundant
+			private void privateFinalMethod() {
 			}
 		}
 	}
@@ -424,17 +450,47 @@ public class TestUnnecessaryModifierCases extends AJavaparserRefactorerCases {
 
 	@CompareCompilationUnitsAsStrings(
 			pre = "public class NestingRecord {\n"
-					+ "		public static final record Person (String name, String address) {}\n"
-					+ "	}",
-			post = "public class NestingRecord {\n" + "		public record Person (String name, String address) {}\n"
-					+ "	}")
-	public static class Issue846_record_nested {
+					+ "\tpublic static final record Person (String name, String address) {}\n"
+					+ "}",
+			post = "public class NestingRecord {\n" + "\tpublic record Person (String name, String address) {}\n" + "}")
+	public static class Issue846_record_nested_within_class {
+	}
+
+	@CompareCompilationUnitsAsStrings(
+			pre = "public interface NestingRecord {\n"
+					+ "\tpublic static final record Person (String name, String address) {}\n"
+					+ "}",
+			post = "public interface NestingRecord {\n"
+					+ "\trecord Person (String name, String address) {}\n"
+					+ "}")
+	public static class Issue846_record_nested_within_interface {
+	}
+
+	@CompareCompilationUnitsAsStrings(
+			pre = "public @interface NestingRecord {\n"
+					+ "\tpublic static final record Person (String name, String address) {}\n"
+					+ "}",
+			post = "public @interface NestingRecord {\n"
+					+ "\trecord Person (String name, String address) {}\n"
+					+ "}")
+	public static class Issue846_record_nested_within_annotation {
+	}
+
+	@CompareCompilationUnitsAsStrings(
+			pre = "public enum NestingRecord {\n" + ";\n"
+					+ "\n"
+					+ "\tpublic static final record Person (String name, String address) {}\n"
+					+ "}",
+			post = "public enum NestingRecord {\n" + ";\n"
+					+ "\n"
+					+ "\tpublic record Person (String name, String address) {}\n"
+					+ "}")
+	public static class Issue846_record_nested_within_enum {
 	}
 
 	@CompareCompilationUnitsAsResources(
-			pre = "/source/do_not_format_me/UnnecessaryModifier/" + "NestingRecord_Issue846_Pre.java",
-			post = "/source/do_not_format_me/UnnecessaryModifier/" + "NestingRecord_Issue846_Post.java")
+			pre = "/source/do_not_format_me/UnnecessaryModifier/NestingRecord_Issue846_Pre.java",
+			post = "/source/do_not_format_me/UnnecessaryModifier/NestingRecord_Issue846_Post.java")
 	public static class Issue846_record_nesting {
 	}
-
 }

--- a/java/src/test/resources/source/do_not_format_me/UnnecessaryModifier/NestingRecord_Issue846_Post.java
+++ b/java/src/test/resources/source/do_not_format_me/UnnecessaryModifier/NestingRecord_Issue846_Post.java
@@ -26,6 +26,6 @@ public record SomeRecord(int i) {
 	public enum SomeEnum {
 	}
 
-	public record SomeRecord(int i) {
+	public record SomeNestedRecord(int i) {
 	}
 }

--- a/java/src/test/resources/source/do_not_format_me/UnnecessaryModifier/NestingRecord_Issue846_Post.java
+++ b/java/src/test/resources/source/do_not_format_me/UnnecessaryModifier/NestingRecord_Issue846_Post.java
@@ -22,4 +22,10 @@ public record SomeRecord(int i) {
 
 	public @interface SomeAnnotation {
 	}
+
+	public enum SomeEnum {
+	}
+
+	public record SomeRecord(int i) {
+	}
 }

--- a/java/src/test/resources/source/do_not_format_me/UnnecessaryModifier/NestingRecord_Issue846_Pre.java
+++ b/java/src/test/resources/source/do_not_format_me/UnnecessaryModifier/NestingRecord_Issue846_Pre.java
@@ -22,4 +22,10 @@ public record SomeRecord(int i) {
 
 	public static abstract @interface SomeAnnotation {
 	}
+
+	public static enum SomeEnum {
+	}
+
+	public static final record SomeRecord(int i) {
+	}
 }

--- a/java/src/test/resources/source/do_not_format_me/UnnecessaryModifier/NestingRecord_Issue846_Pre.java
+++ b/java/src/test/resources/source/do_not_format_me/UnnecessaryModifier/NestingRecord_Issue846_Pre.java
@@ -26,6 +26,6 @@ public record SomeRecord(int i) {
 	public static enum SomeEnum {
 	}
 
-	public static final record SomeRecord(int i) {
+	public static final record SomeNestedRecord(int i) {
 	}
 }


### PR DESCRIPTION
Identifies an opportunity to remove the redundant `final` modifier from private methods (i.e. failing test). Fixes the newly failing test. (TDD)

Note the `final` keyword is not redundant on a non-private static method.

Expands the test case for issue #846, increasing the confidence in merged PR #848 and future refactoring.

