### PR TITLE
chore: do not use classpath-scanning for listing mutators

### DIFF
--- a/meta-tests/pom.xml
+++ b/meta-tests/pom.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>io.github.solven-eu.cleanthat</groupId>
+		<artifactId>aggregator-cleanthat</artifactId>
+		<version>2.23-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>meta-tests</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>io.github.solven-eu.cleanthat</groupId>
+			<artifactId>annotations</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.github.solven-eu.cleanthat</groupId>
+			<artifactId>any-language</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.github.solven-eu.cleanthat</groupId>
+			<artifactId>code-cleaners</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.github.solven-eu.cleanthat</groupId>
+			<artifactId>code-providers</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.github.solven-eu.cleanthat</groupId>
+			<artifactId>config</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.github.solven-eu.cleanthat</groupId>
+			<artifactId>git</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.github.solven-eu.cleanthat</groupId>
+			<artifactId>github</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.github.solven-eu.cleanthat</groupId>
+			<artifactId>gitlab</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.github.solven-eu.cleanthat</groupId>
+			<artifactId>java</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.github.solven-eu.cleanthat</groupId>
+			<artifactId>java-eclipse</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<!--		<dependency>-->
+		<!--			<groupId>io.github.solven-eu.cleanthat</groupId>-->
+		<!--			<artifactId>kotlin</artifactId>-->
+		<!--			<version>${project.version}</version>-->
+		<!--			<scope>test</scope>-->
+		<!--		</dependency>-->
+		<dependency>
+			<groupId>io.github.solven-eu.cleanthat</groupId>
+			<artifactId>lambda</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.github.solven-eu.cleanthat</groupId>
+			<artifactId>local</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.github.solven-eu.cleanthat</groupId>
+			<artifactId>cleanthat-maven-plugin</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.github.solven-eu.cleanthat</groupId>
+			<artifactId>openrewrite</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.github.solven-eu.cleanthat</groupId>
+			<artifactId>refactorer</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.github.solven-eu.cleanthat</groupId>
+			<artifactId>refactorer-test-helpers</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.github.solven-eu.cleanthat</groupId>
+			<artifactId>runnable</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.github.solven-eu.cleanthat</groupId>
+			<artifactId>spotless</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.github.solven-eu.cleanthat</groupId>
+			<artifactId>test-helpers</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<!-- https://stackoverflow.com/questions/1829904/is-there-a-way-to-ignore-a-single-findbugs-warning -->
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>annotations</artifactId>
+			<version>3.0.1u2</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.github.classgraph</groupId>
+			<artifactId>classgraph</artifactId>
+			<version>4.8.180</version>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+</project>

--- a/meta-tests/src/test/java/eu/solven/cleanthat/meta/mutators/MutatorScannerListsAllMutatorsTest.java
+++ b/meta-tests/src/test/java/eu/solven/cleanthat/meta/mutators/MutatorScannerListsAllMutatorsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 Benoit Lacelle - SOLVEN
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.solven.cleanthat.meta.mutators;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import eu.solven.cleanthat.engine.java.refactorer.meta.IMutator;
+import eu.solven.cleanthat.engine.java.refactorer.mutators.scanner.MutatorsScanner;
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.ScanResult;
+
+public class MutatorScannerListsAllMutatorsTest {
+
+	static final String PACKAGE_SINGLE_MUTATORS = "eu.solven.cleanthat.engine.java.refactorer.mutators";
+
+	static final String PACKAGE_COMPOSITE_MUTATORS = "eu.solven.cleanthat.engine.java.refactorer.mutators.composite";
+
+	@Test
+	public void mutatorScannerContainsAllSingleMutators() {
+		Set<Class<? extends IMutator>> expectedSingleMutators = scanSingleMutators();
+
+		Set<Class<? extends IMutator>> mutatorScannerFound = MutatorsScanner.scanSingleMutators();
+
+		assertThat(mutatorScannerFound).as("MutatorsScanner should list all single mutators")
+				.containsExactlyInAnyOrderElementsOf(expectedSingleMutators);
+	}
+
+	@Test
+	public void mutatorScannerContainsAllCompositeMutators() {
+		Set<Class<? extends IMutator>> expectedCompositeMutators = scanCompositeMutators();
+
+		Set<Class<? extends IMutator>> mutatorScannerFound = scanCompositeMutators();
+
+		assertThat(mutatorScannerFound).as("MutatorsScanner should list all composite mutators")
+				.containsExactlyInAnyOrderElementsOf(expectedCompositeMutators);
+	}
+
+	private Set<Class<? extends IMutator>> scanSingleMutators() {
+		return scanMutatorsInPackage(PACKAGE_SINGLE_MUTATORS);
+	}
+
+	private Set<Class<? extends IMutator>> scanCompositeMutators() {
+		return scanMutatorsInPackage(PACKAGE_COMPOSITE_MUTATORS);
+	}
+
+	@SuppressWarnings("unchecked")
+	private Set<Class<? extends IMutator>> scanMutatorsInPackage(String packageName) {
+		try (ScanResult scanResult =
+				new ClassGraph().enableClassInfo().acceptPackagesNonRecursive(packageName).scan()) { // Start the scan
+			return scanResult.getClassesImplementing(IMutator.class)
+					.stream()
+					.filter(classInfo -> !classInfo.isAbstract() && !classInfo.isInterface())
+					.map(ClassInfo::loadClass)
+					.map(clazz -> (Class<? extends IMutator>) clazz)
+					.collect(Collectors.toSet());
+		}
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,9 @@
 		<module>spotless</module>
 
 		<module>openrewrite</module>
+
+		<!-- assert rules on code base -->
+		<module>meta-tests</module>
 	</modules>
 
 	<scm>

--- a/refactorer/src/main/java/eu/solven/cleanthat/engine/java/refactorer/mutators/composite/AllIncludingDraftCompositeMutators.java
+++ b/refactorer/src/main/java/eu/solven/cleanthat/engine/java/refactorer/mutators/composite/AllIncludingDraftCompositeMutators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Benoit Lacelle - SOLVEN
+ * Copyright 2023-2025 Benoit Lacelle - SOLVEN
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,12 +38,9 @@ import eu.solven.cleanthat.engine.java.refactorer.mutators.scanner.MutatorsScann
  */
 public class AllIncludingDraftCompositeMutators extends CompositeMutator<CompositeMutator<?>>
 		implements IConstructorNeedsJdkVersion {
-	// This packageName is not part of the public API
-	@Deprecated
-	static final String PACKAGE_COMPOSITE_MUTATORS = "eu.solven.cleanthat.engine.java.refactorer.mutators.composite";
 
 	static final Supplier<List<Class<? extends CompositeMutator<?>>>> ALL_INCLUDINGDRAFT =
-			Suppliers.memoize(() -> MutatorsScanner.scanPackageMutators(PACKAGE_COMPOSITE_MUTATORS)
+			Suppliers.memoize(() -> MutatorsScanner.scanCompositeMutators()
 					.stream()
 					// Exclude itself
 					.filter(m -> !m.equals(AllIncludingDraftCompositeMutators.class))
@@ -51,7 +48,7 @@ public class AllIncludingDraftCompositeMutators extends CompositeMutator<Composi
 					.map(m -> (Class<? extends CompositeMutator<?>>) m)
 
 					// Sort by className, to always apply mutators in the same order
-					.sorted(Comparator.comparing(m -> m.getClass().getName()))
+					.sorted(Comparator.comparing(Class::getName))
 					.collect(Collectors.toList()));
 
 	/**

--- a/refactorer/src/main/java/eu/solven/cleanthat/engine/java/refactorer/mutators/composite/AllIncludingDraftSingleMutators.java
+++ b/refactorer/src/main/java/eu/solven/cleanthat/engine/java/refactorer/mutators/composite/AllIncludingDraftSingleMutators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Benoit Lacelle - SOLVEN
+ * Copyright 2023-2025 Benoit Lacelle - SOLVEN
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,14 +36,12 @@ import eu.solven.cleanthat.engine.java.refactorer.mutators.scanner.MutatorsScann
  */
 public class AllIncludingDraftSingleMutators extends CompositeMutator<IMutator> implements IConstructorNeedsJdkVersion {
 	// This packageName is not part of the public API
-	@Deprecated
-	static final String PACKAGE_SINGLE_MUTATORS = "eu.solven.cleanthat.engine.java.refactorer.mutators";
 
 	static final Supplier<List<Class<? extends IMutator>>> ALL_INCLUDINGDRAFT =
-			Suppliers.memoize(() -> MutatorsScanner.scanPackageMutators(PACKAGE_SINGLE_MUTATORS)
+			Suppliers.memoize(() -> MutatorsScanner.scanSingleMutators()
 					.stream()
 					// Sort by className, to always apply mutators in the same order
-					.sorted(Comparator.comparing(m -> m.getName()))
+					.sorted(Comparator.comparing(Class::getName))
 					.collect(Collectors.toList()));
 
 	public AllIncludingDraftSingleMutators(JavaVersion sourceJdkVersion) {


### PR DESCRIPTION
Hey there @blacelle 

I'm working on a [spotless cli](https://github.com/diffplug/spotless-cli). It is a graalvm-compiled native binary of the spotless formatter.

I've failed to integrate cleanthat so far, just due to the classpath-scanning approach cleanthat uses to find its mutator implementations.

This PR is my proposal on how we can get rid of classpath scanning in cleanthat to find mutators, by listing the mutators explicitly and ensuring none is forgotten using a unit-test that makes sure of that.

Would be awesome if we could merge this and create a new release so I can integrate cleanthat with spotless-cli 👍 